### PR TITLE
feat: add blurhash image placeholders

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,11 @@
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource-variable/outfit": "^5.2.8",
     "@tailwindcss/vite": "^4.1.18",
+    "@unpic/placeholder": "^0.1.2",
     "astro": "^5.18.0",
     "astro-icon": "^1.1.5",
     "astro-seo": "^1.1.0",
+    "blurhash": "^2.0.5",
     "remark-math": "^6.0.0",
     "sharp": "^0.34.5",
     "tailwindcss": "^4.1.18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@6.4.1(@types/node@25.0.10)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@unpic/placeholder':
+        specifier: ^0.1.2
+        version: 0.1.2
       astro:
         specifier: ^5.18.0
         version: 5.18.0(@types/node@25.0.10)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.56.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -32,6 +35,9 @@ importers:
       astro-seo:
         specifier: ^1.1.0
         version: 1.1.0(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@5.9.3)
+      blurhash:
+        specifier: ^2.0.5
+        version: 2.0.5
       remark-math:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1369,6 +1375,9 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
+  '@unpic/placeholder@0.1.2':
+    resolution: {integrity: sha512-O++tS97biojo5sqn5TeTt+jUjl5gWOdIQuOXe8YluTJWq4L0GM6VuTkaspNpsmxHfioJw/6YBirzOpG4t87l8Q==}
+
   '@volar/kit@2.4.27':
     resolution: {integrity: sha512-ilZoQDMLzqmSsImJRWx4YiZ4FcvvPrPnFVmL6hSsIWB6Bn3qc7k88J9yP32dagrs5Y8EXIlvvD/mAFaiuEOACQ==}
     peerDependencies:
@@ -1479,6 +1488,9 @@ packages:
 
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
+  blurhash@2.0.5:
+    resolution: {integrity: sha512-cRygWd7kGBQO3VEhPiTgq4Wc43ctsM+o46urrmPOiuAe+07fzlSB9OJVdpgDL0jPqXUVQ9ht7aq7kxOeJHRK+w==}
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
@@ -4020,6 +4032,10 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@unpic/placeholder@0.1.2':
+    dependencies:
+      blurhash: 2.0.5
+
   '@volar/kit@2.4.27(typescript@5.9.3)':
     dependencies:
       '@volar/language-service': 2.4.27
@@ -4239,6 +4255,8 @@ snapshots:
   base-64@1.0.0: {}
 
   blake3-wasm@2.1.5: {}
+
+  blurhash@2.0.5: {}
 
   boolbase@1.0.0: {}
 

--- a/src/components/general/ProjectCard.astro
+++ b/src/components/general/ProjectCard.astro
@@ -1,6 +1,6 @@
 ---
-import { Image } from "astro:assets";
 import type { CollectionEntry } from "astro:content";
+import BlurImage from "@/components/ui/BlurImage.astro";
 import StatusBadge from "@/components/ui/StatusBadge.astro";
 
 interface Props {
@@ -21,13 +21,13 @@ const {
 <article class="group bg-card relative aspect-4/3 w-full overflow-hidden rounded-xl border shadow-xl">
   <a href={`/${collection}/${slug}`} aria-label={`Projekt: ${title}`}>
     {status && <StatusBadge status={status} />}
-    <Image
+    <BlurImage
       src={thumbnail}
-      class="size-full object-cover object-center brightness-90 transition duration-300 group-hover:scale-105"
-      loading={lazy ? "lazy" : "eager"}
-      width={600}
-      quality="high"
       alt={`Preview for ${title}`}
+      width={600}
+      loading={lazy ? "lazy" : "eager"}
+      class="size-full"
+      imgClass="brightness-90 transition duration-300 group-hover:scale-105"
     />
     <div class="absolute bottom-0 left-0 w-full bg-black/30 p-4 backdrop-blur-sm">
       <h3 class="mr-2 text-xl font-semibold text-white">{title}</h3>

--- a/src/components/ui/BlurImage.astro
+++ b/src/components/ui/BlurImage.astro
@@ -1,0 +1,32 @@
+---
+import { Image } from "astro:assets";
+import { generateBlurhashCss } from "@/utils/blurhash";
+
+interface Props {
+  src: ImageMetadata;
+  alt: string;
+  width: number;
+  loading?: "lazy" | "eager";
+  quality?: "low" | "mid" | "high" | "max" | number;
+  class?: string;
+  imgClass?: string;
+}
+
+const { src, alt, width, loading = "lazy", quality = "high", class: className, imgClass } = Astro.props;
+
+const blurhashCss = await generateBlurhashCss(src);
+---
+
+<div
+  class:list={["relative overflow-hidden", className]}
+  style={`background-image:${blurhashCss};background-size:cover`}
+>
+  <Image
+    src={src}
+    alt={alt}
+    width={width}
+    quality={quality}
+    loading={loading}
+    class:list={["size-full object-cover object-center", imgClass]}
+  />
+</div>

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -1,7 +1,7 @@
 ---
-import { Image } from "astro:assets";
 import { type CollectionEntry, getCollection } from "astro:content";
 import PageHeader from "@/components/general/PageHeader.astro";
+import BlurImage from "@/components/ui/BlurImage.astro";
 import Layout from "@/layouts/Layout.astro";
 import { statusConfig } from "@/utils/status";
 
@@ -38,13 +38,12 @@ const { Content } = await entry.render();
     liveUrl={data.liveUrl}
     docsUrl={data.docsUrl}
   />
-  <Image
-    class="aspect-4/3 size-full overflow-hidden rounded-xl object-cover object-center brightness-90 sm:aspect-2/1"
+  <BlurImage
     src={data.thumbnail}
-    loading="eager"
-    width={800}
-    quality="high"
     alt={data.title}
+    width={800}
+    loading="eager"
+    class="aspect-4/3 overflow-hidden rounded-xl brightness-90 sm:aspect-2/1"
   />
   <section class="grid grid-cols-1 gap-16 md:grid-cols-2 md:gap-8 lg:grid-cols-3">
     <dl class="grid grid-cols-1 content-start gap-8 sm:grid-cols-2 md:grid-cols-1">

--- a/src/utils/blurhash.ts
+++ b/src/utils/blurhash.ts
@@ -1,0 +1,18 @@
+import { blurhashToCssGradientString } from "@unpic/placeholder";
+import { encode } from "blurhash";
+import sharp from "sharp";
+
+export async function generateBlurhashCss(image: ImageMetadata): Promise<string> {
+  // fsPath is available at runtime via Astro's Proxy but not in the type definition
+  const fsPath = (image as ImageMetadata & { fsPath: string }).fsPath;
+  const size = 32;
+  const { data, info } = await sharp(fsPath)
+    .resize(size, size, { fit: "cover" })
+    .ensureAlpha()
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+
+  const hash = encode(new Uint8ClampedArray(data), info.width, info.height, 4, 4);
+
+  return blurhashToCssGradientString(hash);
+}


### PR DESCRIPTION
## Summary

- Add CSS-based blurhash image placeholders generated at build time with zero client-side JavaScript
- New `BlurImage` component wraps Astro's `Image` with a blurhash background that shows while the image loads
- New `src/utils/blurhash.ts` utility converts blurhash strings to CSS gradient backgrounds via `@unpic/placeholder`
- Updated `ProjectCard` and project detail page (`[slug].astro`) to use `BlurImage` instead of `Image`