### PR TITLE
fix: hide alt text on blurred placeholder images

### DIFF
--- a/src/components/ui/BlurImage.astro
+++ b/src/components/ui/BlurImage.astro
@@ -27,6 +27,6 @@ const blurhashCss = await generateBlurhashCss(src);
     width={width}
     quality={quality}
     loading={loading}
-    class:list={["size-full object-cover object-center", imgClass]}
+    class:list={["size-full object-cover object-center text-transparent", imgClass]}
   />
 </div>


### PR DESCRIPTION
## Summary
- Add `text-transparent` to the `<Image>` `class:list` in `BlurImage.astro` so alt text is invisible on the blurred placeholder while remaining accessible to screen readers